### PR TITLE
feat: add RSVP feature page route and nav link (I.1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Layout from "./components/layout/Layout";
 import EventsPage from "./components/pages/EventsPage";
 import ServicesPage from "./components/pages/ServicesPage";
+import RsvpPage from "./components/pages/RsvpPage";
 
 function App() {
   const [sharedMessage, setSharedMessage] = useState("Hello from shared state");
@@ -32,6 +33,17 @@ function App() {
             />
           }
         />
+
+        <Route
+          path="rsvp"
+          element={
+            <RsvpPage
+              sharedMessage={sharedMessage}
+              setSharedMessage={setSharedMessage}
+            />
+          }
+        />
+
       </Route>
     </Routes>
   );

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -17,6 +17,9 @@ function Nav() {
         <li>
           <NavLink to="/services">Services</NavLink>
         </li>
+        <li>
+          <NavLink to="/rsvp">RSVP</NavLink>
+        </li>
       </ul>
     </nav>
   );

--- a/src/components/pages/RsvpPage.tsx
+++ b/src/components/pages/RsvpPage.tsx
@@ -1,0 +1,48 @@
+type RsvpPageProps = {
+  sharedMessage: string;
+  setSharedMessage: (newMessage: string) => void;
+};
+
+function RsvpPage({ sharedMessage, setSharedMessage }: RsvpPageProps) {
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "24px 16px" }}>
+      <h2 style={{ textAlign: "center", marginBottom: 8 }}>RSVP Page</h2>
+
+      <p style={{ textAlign: "center", marginTop: 0 }}>
+        <strong>Shared:</strong> {sharedMessage}
+      </p>
+
+      <div
+        style={{
+          border: "1px solid #ddd",
+          borderRadius: 10,
+          padding: 16,
+          marginTop: 16,
+          background: "#fff",
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Feature Page (I.1)</h3>
+
+        <p style={{ marginBottom: 12 }}>
+          This page proves routing + shared state props. Click the button to
+          update shared state across pages.
+        </p>
+
+        <button
+          type="button"
+          onClick={() => setSharedMessage("Updated from RSVP page")}
+          style={{
+            padding: "10px 14px",
+            borderRadius: 8,
+            border: "1px solid #bbb",
+            cursor: "pointer",
+          }}
+        >
+          Update shared message
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default RsvpPage;


### PR DESCRIPTION
Added the RSVP feature page as its own routed page, wired route in App.tsx using existing Layout
Added navigation link to the RSVP page and age receives, and updates shared state via props